### PR TITLE
Change orm session creation

### DIFF
--- a/aldjemy/orm.py
+++ b/aldjemy/orm.py
@@ -13,9 +13,8 @@ from .table import get_django_models
 def get_session(alias='default'):
     connection = connections[alias]
     if not hasattr(connection, 'sa_session'):
-        session = orm.create_session()
-        session.bind = get_engine(alias)
-        connection.sa_session = session
+        session = orm.sessionmaker(bind=get_engine(alias))
+        connection.sa_session = session()
     return connection.sa_session
 
 


### PR DESCRIPTION
According SqlAlchemy documentation should use sessionmaker instead of create_session 
From changelog version 0.6.4:
The Session class is now present in sqlalchemy.orm.*. We’re moving away from the usage of create_session(), which has non-standard defaults, for those situations where a one-step Session constructor is desired. Most users should stick with sessionmaker() for general use, however.
